### PR TITLE
chore: fix the way to use cybozu/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["@cybozu"]
+  "extends": ["github>cybozu/renovate-config"]
 }


### PR DESCRIPTION
We use cybozu/renovate-config as `@cybozu`, but it's not an official way that the document describes.
https://docs.renovatebot.com/config-presets/